### PR TITLE
chore: updated package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ https://github.com/user-attachments/assets/e19af1f4-e933-4118-8a9c-0202bf3fb020
 Install the Drawing Tool package via Yarn:
 
 ```bash
-yarn add @blade47/drawing-tool
+yarn add @blade47/editorjs-drawing-tool
 ```
 
 ### Import the Module
@@ -33,7 +33,7 @@ yarn add @blade47/drawing-tool
 To use the tool in your project, include it as:
 
 ```javascript
-import DrawingTool from '@blade47/drawing-tool';
+import DrawingTool from '@blade47/editorjs-drawing-tool';
 ```
 
 ---


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the package name from `@blade47/drawing-tool` to `@blade47/editorjs-drawing-tool` in the installation instructions and import statements.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R36): Updated the package name in the Yarn installation command and import statement.